### PR TITLE
Removed dependency on parent pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,27 +1,77 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>com.bnorm</groupId>
-        <artifactId>bnorm-parent</artifactId>
-        <version>1.0.0</version>
-    </parent>
 
     <groupId>com.bnorm.fsm4j.users.${user.name}</groupId>
     <artifactId>fsm4j</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <name>Finite State Machine for Java</name>
+    <name>fsm4j</name>
+    <description>Finite State Machine for Java</description>
+    <url>https://github.com/bnormsoftware/fsm4j</url>
+
+    <organization>
+        <name>BNORM Software</name>
+        <url>https://www.bnorm.com</url>
+    </organization>
+
+    <issueManagement>
+        <url>https://github.com/bnormsoftware/fsm4j/issues</url>
+        <system>GitHub Issues</system>
+    </issueManagement>
+
+    <scm>
+        <url>https://github.com/bnormsoftware/fsm4j</url>
+        <connection>scm:git:git://github.com/bnormsoftware/fsm4j.git</connection>
+        <developerConnection>scm:git:git@github.com:bnormsoftware/fsm4j.git</developerConnection>
+    </scm>
+
+    <developers>
+        <developer>
+            <name>Brian Norman</name>
+            <url>https://github.com/bnorm</url>
+            <id>bnorm</id>
+        </developer>
+    </developers>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.0.2</version>
+                <version>3.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fixes #4 

The BNORM Software parent pom file is only available to BNORM Software developers.  This causes building the project for anyone outside of BNORM Software.  By removing the dependency, other developers will be able to use this project.
