### PR TITLE
Made base implementations extendable

### DIFF
--- a/src/main/java/com/bnorm/fsm4j/InternalStateBase.java
+++ b/src/main/java/com/bnorm/fsm4j/InternalStateBase.java
@@ -14,7 +14,7 @@ import java.util.Set;
  * @version 1.0
  * @since 1.0
  */
-class InternalStateBase<S extends State, E extends Event> implements InternalState<S, E> {
+public class InternalStateBase<S extends State, E extends Event> implements InternalState<S, E> {
 
     /** The wrapped state. */
     private final S state;
@@ -36,7 +36,7 @@ class InternalStateBase<S extends State, E extends Event> implements InternalSta
      *
      * @param state the state to wrap.
      */
-    InternalStateBase(S state) {
+    protected InternalStateBase(S state) {
         this.state = state;
         this.parent = Optional.empty();
         this.children = new HashSet<>();

--- a/src/main/java/com/bnorm/fsm4j/StateBuilderBase.java
+++ b/src/main/java/com/bnorm/fsm4j/StateBuilderBase.java
@@ -13,7 +13,7 @@ import java.util.Set;
  * @version 1.0
  * @since 1.0
  */
-class StateBuilderBase<S extends State, E extends Event> implements StateBuilder<S, E> {
+public class StateBuilderBase<S extends State, E extends Event> implements StateBuilder<S, E> {
 
     /** The state machine state to internal state map. */
     private final Map<S, InternalState<S, E>> states;
@@ -31,7 +31,7 @@ class StateBuilderBase<S extends State, E extends Event> implements StateBuilder
      * @param transitions the transitions of the state machine.
      * @param state the internal state being built.
      */
-    public StateBuilderBase(Map<S, InternalState<S, E>> states, Map<E, Set<Transition<S>>> transitions,
+    protected StateBuilderBase(Map<S, InternalState<S, E>> states, Map<E, Set<Transition<S>>> transitions,
                             InternalState<S, E> state) {
         this.states = states;
         this.transitions = transitions;

--- a/src/main/java/com/bnorm/fsm4j/StateMachineBase.java
+++ b/src/main/java/com/bnorm/fsm4j/StateMachineBase.java
@@ -13,7 +13,7 @@ import java.util.Set;
  * @version 1.0
  * @since 1.0
  */
-class StateMachineBase<S extends State, E extends Event> implements StateMachine<S, E> {
+public class StateMachineBase<S extends State, E extends Event> implements StateMachine<S, E> {
 
     /** The state machine transition listeners. */
     private final Set<TransitionListener<S, E>> listeners;
@@ -34,7 +34,7 @@ class StateMachineBase<S extends State, E extends Event> implements StateMachine
      * @param transitions the transitions of the state machine.
      * @param starting the starting state of the state machine.
      */
-    StateMachineBase(Map<S, InternalState<S, E>> states, Map<E, Set<Transition<S>>> transitions, S starting) {
+    protected StateMachineBase(Map<S, InternalState<S, E>> states, Map<E, Set<Transition<S>>> transitions, S starting) {
         this.listeners = new HashSet<>();
         this.states = states;
         this.transitions = transitions;

--- a/src/main/java/com/bnorm/fsm4j/TransitionBase.java
+++ b/src/main/java/com/bnorm/fsm4j/TransitionBase.java
@@ -8,7 +8,7 @@ package com.bnorm.fsm4j;
  * @version 1.0
  * @since 1.0
  */
-class TransitionBase<S extends State> implements Transition<S> {
+public class TransitionBase<S extends State> implements Transition<S> {
 
     /** The source state of the transition. */
     private final S source;
@@ -22,7 +22,7 @@ class TransitionBase<S extends State> implements Transition<S> {
      * @param source the source state of the transition.
      * @param destination the destination state of the transition.
      */
-    TransitionBase(S source, S destination) {
+    protected TransitionBase(S source, S destination) {
         this.source = source;
         this.destination = destination;
     }


### PR DESCRIPTION
Fixes #2 

The base implementations were package private before which made them impossible to extent.  Extension is the easiest way to add just a little functionality without having to rewrite the implementation.
