### PR TITLE
Fixed issue with parent transition filtering

### DIFF
--- a/src/main/java/com/bnorm/fsm4j/StateMachine.java
+++ b/src/main/java/com/bnorm/fsm4j/StateMachine.java
@@ -73,8 +73,10 @@ public interface StateMachine<S extends State, E extends Event> {
                                                                .collect(Collectors.toList());
         if (transitions.isEmpty()) {
             final Optional<InternalState<S, E>> parent = getInternalState(getState()).getParentState();
-            parent.ifPresent(p -> transitions.addAll(
-                    getTransitions(event).stream().filter(t -> t.getSource().equals(p)).collect(Collectors.toList())));
+            parent.ifPresent(p -> transitions.addAll(getTransitions(event).stream()
+                                                                          .filter(t -> t.getSource()
+                                                                                        .equals(p.getState()))
+                                                                          .collect(Collectors.toList())));
         }
 
         if (transitions.isEmpty()) {


### PR DESCRIPTION
When no transition are found for the specific InternalState, the parent
of the state is checked for possible transitions.  The filtering of the
transition set was performed by the InternalState rather than the State
value of the parent.

Fixes #13 
