### PR TITLE
Protection against parent state not existing

### DIFF
--- a/src/main/java/com/bnorm/fsm4j/StateBuilderBase.java
+++ b/src/main/java/com/bnorm/fsm4j/StateBuilderBase.java
@@ -48,9 +48,15 @@ public class StateBuilderBase<S extends State, E extends Event, C extends Contex
     @Override
     public StateBuilderBase<S, E, C> childOf(S parent) {
         InternalState<S, E, C> internalParent = states.get(parent);
-        internalParent.addChild(getInternalState());
-        getInternalState().setParentState(internalParent);
-        return this;
+        if (internalParent != null) {
+            internalParent.addChild(getInternalState());
+            getInternalState().setParentState(internalParent);
+            return this;
+        } else {
+            throw new StateMachineException(
+                    "Requested parent state [" + parent + "] does not exist in the state machine." +
+                            "  Configure parent states before configuring children states.");
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #20 

When calling the StateBuilder.childOf(...) method, if the specified
parent state does not exist yet in the state machine, a
NullPointerException will be thrown.  This change protects against the
null pointer and throws a more specific StateMachineException instead
which describes the problem and how to fix it.
