### PR TITLE
Making returned sets immutable

### DIFF
--- a/src/main/java/com/bnorm/fsm4j/StateMachineBase.java
+++ b/src/main/java/com/bnorm/fsm4j/StateMachineBase.java
@@ -71,12 +71,12 @@ public class StateMachineBase<S extends State, E extends Event, C extends Contex
 
     @Override
     public Set<Transition<S>> getTransitions(E event) {
-        return transitions.getOrDefault(event, Collections.emptySet());
+        return Collections.unmodifiableSet(transitions.getOrDefault(event, Collections.emptySet()));
     }
 
     @Override
     public Set<TransitionListener<S, E>> getTransitionListeners() {
-        return listeners;
+        return Collections.unmodifiableSet(listeners);
     }
 
     @Override


### PR DESCRIPTION
Fixes #21 

Whenever a collection is returned from an object it should be returned
as an unmodifiable collection.  This keeps anyone outside of the object
from modifying the collection in any way.
