### PR TITLE
Made factory types consistent

### DIFF
--- a/src/main/java/com/bnorm/fsm4j/StateMachineBase.java
+++ b/src/main/java/com/bnorm/fsm4j/StateMachineBase.java
@@ -33,7 +33,7 @@ public class StateMachineBase<S, E, C> implements StateMachine<S, E, C> {
     private final C context;
 
     /**
-     * Constructs a new state machine from the specified state map, transition map, and starting state.
+     * Constructs a new state machine from the specified state map, transition map, starting state, and context.
      *
      * @param states the states of the state machine.
      * @param transitions the transitions of the state machine.

--- a/src/main/java/com/bnorm/fsm4j/StateMachineFactory.java
+++ b/src/main/java/com/bnorm/fsm4j/StateMachineFactory.java
@@ -6,33 +6,33 @@ import java.util.Set;
 /**
  * A factory interface for state machines.
  *
- * @param <S> the class type of the states.
- * @param <E> the class type of the events.
- * @param <C> the class type of the context.
  * @author Brian Norman
  * @version 1.0
  * @since 1.0
  */
-public interface StateMachineFactory<S, E, C> {
+public interface StateMachineFactory {
 
     /**
      * Returns the default internal state factory.  This is the internal state base constructor.
      *
      * @return default internal state factory.
      */
-    static <S, E, C> StateMachineFactory<S, E, C> getDefault() {
+    static StateMachineFactory getDefault() {
         return StateMachineBase::new;
     }
 
     /**
-     * Creates a state machine from the specified state map, transition map, and starting state.
+     * Creates a state machine from the specified state map, transition map, starting state, and context.
      *
      * @param states the states of the state machine.
      * @param transitions the transitions of the state machine.
      * @param starting the starting state of the state machine.
      * @param context the state machine context.
+     * @param <S> the class type of the states.
+     * @param <E> the class type of the events.
+     * @param <C> the class type of the context.
      * @return a state machine.
      */
-    StateMachine<S, E, C> create(Map<S, InternalState<S, E, C>> states, Map<E, Set<Transition<S>>> transitions,
-                                 S starting, C context);
+    <S, E, C> StateMachine<S, E, C> create(Map<S, InternalState<S, E, C>> states,
+                                           Map<E, Set<Transition<S>>> transitions, S starting, C context);
 }

--- a/src/main/java/com/bnorm/fsm4j/TransitionFactory.java
+++ b/src/main/java/com/bnorm/fsm4j/TransitionFactory.java
@@ -4,19 +4,18 @@ import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
 /**
- * @param <S> the class type of the states.
  * @author Brian Norman
  * @version 1.0
  * @since 1.0
  */
-public interface TransitionFactory<S> {
+public interface TransitionFactory {
 
     /**
      * Returns the default internal state factory.  This is the internal state base constructor.
      *
      * @return default internal state factory.
      */
-    static <S> TransitionFactory<S> getDefault() {
+    static TransitionFactory getDefault() {
         return TransitionBase::new;
     }
 
@@ -25,9 +24,10 @@ public interface TransitionFactory<S> {
      *
      * @param source the source state of the transition.
      * @param destination the destination state of the transition.
+     * @param <S> the class type of the states.
      * @return a transition.
      */
-    default TransitionBase<S> create(S source, S destination) {
+    default <S> TransitionBase<S> create(S source, S destination) {
         return create(source, destination, Optional.empty());
     }
 
@@ -37,9 +37,10 @@ public interface TransitionFactory<S> {
      * @param source the source state of the transition.
      * @param destination the destination state of the transition.
      * @param conditional the conditional nature of the transition.
+     * @param <S> the class type of the states.
      * @return a transition.
      */
-    default TransitionBase<S> create(S source, S destination, BooleanSupplier conditional) {
+    default <S> TransitionBase<S> create(S source, S destination, BooleanSupplier conditional) {
         return create(source, destination, Optional.of(conditional));
     }
 
@@ -49,7 +50,8 @@ public interface TransitionFactory<S> {
      * @param source the source state of the transition.
      * @param destination the destination state of the transition.
      * @param conditional the conditional nature of the transition.
+     * @param <S> the class type of the states.
      * @return a transition.
      */
-    TransitionBase<S> create(S source, S destination, Optional<BooleanSupplier> conditional);
+    <S> TransitionBase<S> create(S source, S destination, Optional<BooleanSupplier> conditional);
 }

--- a/src/main/java/com/bnorm/fsm4j/builders/StateBuilderBase.java
+++ b/src/main/java/com/bnorm/fsm4j/builders/StateBuilderBase.java
@@ -33,17 +33,18 @@ public class StateBuilderBase<S, E, C> implements StateBuilder<S, E, C> {
     private final InternalState<S, E, C> state;
 
     /** The state transition factory. */
-    private final TransitionFactory<S> transitionFactory;
+    private final TransitionFactory transitionFactory;
 
     /**
-     * Constructs a new state builder from the specified state map, transition map, and internal state being built.
+     * Constructs a new state builder from the specified transition factory, state map, transition map, and internal
+     * state being built.
      *
      * @param transitionFactory the factory used to create transitions.
      * @param states the states of the state machine.
      * @param transitions the transitions of the state machine.
      * @param state the internal state being built.
      */
-    protected StateBuilderBase(TransitionFactory<S> transitionFactory, Map<S, InternalState<S, E, C>> states,
+    protected StateBuilderBase(TransitionFactory transitionFactory, Map<S, InternalState<S, E, C>> states,
                                Map<E, Set<Transition<S>>> transitions, InternalState<S, E, C> state) {
         this.states = states;
         this.transitions = transitions;

--- a/src/main/java/com/bnorm/fsm4j/builders/StateBuilderFactory.java
+++ b/src/main/java/com/bnorm/fsm4j/builders/StateBuilderFactory.java
@@ -10,35 +10,34 @@ import com.bnorm.fsm4j.TransitionFactory;
 /**
  * A factory interface for state builders.
  *
- * @param <S> the class type of the states.
- * @param <E> the class type of the events.
- * @param <C> the class type of the context.
  * @author Brian Norman
  * @version 1.0
  * @since 1.0
  */
-public interface StateBuilderFactory<S, E, C> {
+public interface StateBuilderFactory {
 
     /**
      * Returns the default state builder factory.  This is the state builder base constructor.
      *
-     * @param <S> the class type of the states.
-     * @param <E> the class type of the events.
      * @return default state builder factory.
      */
-    static <S, E, C> StateBuilderFactory<S, E, C> getDefault() {
+    static StateBuilderFactory getDefault() {
         return StateBuilderBase::new;
     }
 
     /**
-     * Creates a new state builder from the specified state map, transition map, and internal state being built.
+     * Creates a new state builder from the specified transition factory, state map, transition map, and internal state
+     * being built.
      *
      * @param transitionFactory the factory used to create transitions.
      * @param states the states of the state machine.
      * @param transitions the transitions of the state machine.
      * @param state the internal state being built.
+     * @param <S> the class type of the states.
+     * @param <E> the class type of the events.
+     * @param <C> the class type of the context.
      * @return a new state builder.
      */
-    StateBuilder<S, E, C> create(TransitionFactory<S> transitionFactory, Map<S, InternalState<S, E, C>> states,
-                                 Map<E, Set<Transition<S>>> transitions, InternalState<S, E, C> state);
+    <S, E, C> StateBuilder<S, E, C> create(TransitionFactory transitionFactory, Map<S, InternalState<S, E, C>> states,
+                                           Map<E, Set<Transition<S>>> transitions, InternalState<S, E, C> state);
 }

--- a/src/main/java/com/bnorm/fsm4j/builders/StateMachineBuilderBase.java
+++ b/src/main/java/com/bnorm/fsm4j/builders/StateMachineBuilderBase.java
@@ -21,20 +21,19 @@ import com.bnorm.fsm4j.TransitionFactory;
  * @version 1.0
  * @since 1.0
  */
-public class StateMachineBuilderBase<S, E, C>
-        implements StateMachineBuilder<S, E, C> {
+public class StateMachineBuilderBase<S, E, C> implements StateMachineBuilder<S, E, C> {
 
     /** The state machine builder internal state factory. */
     private final InternalStateFactory stateFactory;
 
     /** The state transition factory. */
-    private final TransitionFactory<S> transitionFactory;
+    private final TransitionFactory transitionFactory;
 
     /** The state machine builder state machine factory. */
-    private final StateMachineFactory<S, E, C> stateMachineFactory;
+    private final StateMachineFactory stateMachineFactory;
 
     /** The state machine builder state builder factory. */
-    private final StateBuilderFactory<S, E, C> configurationFactory;
+    private final StateBuilderFactory configurationFactory;
 
     /** The state to internal state map. */
     private final Map<S, InternalState<S, E, C>> states;
@@ -44,16 +43,17 @@ public class StateMachineBuilderBase<S, E, C>
 
 
     /**
-     * Constructs a new state machine builder from the specified state builder factory and internal state factory.
+     * Constructs a new state machine builder from the specified internal state factory, transition factory, state
+     * builder factory, and state machine factory.
      *
      * @param internalStateFactory the factory used to create internal states.
      * @param transitionFactory the factory used to create transitions.
-     * @param stateMachineFactory the factory used to create the state machine.
      * @param stateBuilderFactory the factory used to create state builders.
+     * @param stateMachineFactory the factory used to create the state machine.
      */
-    protected StateMachineBuilderBase(InternalStateFactory internalStateFactory, TransitionFactory<S> transitionFactory,
-                                      StateMachineFactory<S, E, C> stateMachineFactory,
-                                      StateBuilderFactory<S, E, C> stateBuilderFactory) {
+    protected StateMachineBuilderBase(InternalStateFactory internalStateFactory, TransitionFactory transitionFactory,
+                                      StateBuilderFactory stateBuilderFactory,
+                                      StateMachineFactory stateMachineFactory) {
         this.stateFactory = internalStateFactory;
         this.transitionFactory = transitionFactory;
         this.stateMachineFactory = stateMachineFactory;

--- a/src/main/java/com/bnorm/fsm4j/builders/StateMachineBuilderFactory.java
+++ b/src/main/java/com/bnorm/fsm4j/builders/StateMachineBuilderFactory.java
@@ -7,24 +7,18 @@ import com.bnorm.fsm4j.TransitionFactory;
 /**
  * A factory interface for state machine builders.
  *
- * @param <S> the class type of the states.
- * @param <E> the class type of the events.
- * @param <C> the class type of the context.
  * @author Brian Norman
  * @version 1.0
  * @since 1.0
  */
-public interface StateMachineBuilderFactory<S, E, C> {
+public interface StateMachineBuilderFactory {
 
     /**
      * Creates the default state machine builder factory.  This is the state machine builder base constructor.
      *
-     * @param <S> the class type of the states.
-     * @param <E> the class type of the events.
-     * @param <C> the class type of the context.
      * @return default state machine builder factory.
      */
-    static <S, E, C> StateMachineBuilderFactory<S, E, C> getDefault() {
+    static StateMachineBuilderFactory getDefault() {
         return StateMachineBuilderBase::new;
     }
 
@@ -40,21 +34,21 @@ public interface StateMachineBuilderFactory<S, E, C> {
     static <S, E, C> StateMachineBuilder<S, E, C> create() {
         return StateMachineBuilderFactory.<S, E, C>getDefault()
                                          .create(InternalStateFactory.getDefault(), TransitionFactory.getDefault(),
-                                                 StateMachineFactory.getDefault(), StateBuilderFactory.getDefault());
+                                                 StateBuilderFactory.getDefault(), StateMachineFactory.getDefault());
     }
 
     /**
-     * Creates a state machine builder from the specified internal state factory, transition factory, state machine
-     * factory, and state builder factory.
+     * Creates a state machine builder from the specified internal state factory, transition factory, state builder
+     * factory, and state machine factory.
      *
      * @param internalStateFactory the factory used to create internal states.
      * @param transitionFactory the factory used to create transitions.
-     * @param stateMachineFactory the factory used to create the state machine.
      * @param stateBuilderFactory the factory used to create state builders.
+     * @param stateMachineFactory the factory used to create the state machine.
      * @return a state machine builder.
      */
-    StateMachineBuilder<S, E, C> create(InternalStateFactory internalStateFactory,
-                                        TransitionFactory<S> transitionFactory,
-                                        StateMachineFactory<S, E, C> stateMachineFactory,
-                                        StateBuilderFactory<S, E, C> stateBuilderFactory);
+    <S, E, C> StateMachineBuilder<S, E, C> create(InternalStateFactory internalStateFactory,
+                                                  TransitionFactory transitionFactory,
+                                                  StateBuilderFactory stateBuilderFactory,
+                                                  StateMachineFactory stateMachineFactory);
 }


### PR DESCRIPTION
Fixes #17 

All the factories except for the internal state factory required the
types parameters of the objects being create to be specified when the
factory was created.  The internal state factory only required those
type parameters when the objects were created by the factory.  In
practice, this design proved to be a little more effective thought not
by much.  All factories now follow this design.
