### PR TITLE
Transition listeners should have access to state machine context

### DIFF
--- a/src/main/java/com/bnorm/fsm4j/StateMachine.java
+++ b/src/main/java/com/bnorm/fsm4j/StateMachine.java
@@ -60,14 +60,14 @@ public interface StateMachine<S, E, C> {
      *
      * @return all transition listeners.
      */
-    Set<TransitionListener<? super S, ? super E>> getTransitionListeners();
+    Set<TransitionListener<? super S, ? super E, ? super C>> getTransitionListeners();
 
     /**
      * Adds the specified transition listener to the state machine.
      *
      * @param listener the new transition listener.
      */
-    void addTransitionListener(TransitionListener<? super S, ? super E> listener);
+    void addTransitionListener(TransitionListener<? super S, ? super E, ? super C> listener);
 
     /**
      * Fires the specified event.  This is how states are transitioned.
@@ -104,7 +104,7 @@ public interface StateMachine<S, E, C> {
         setState(transition.getDestination());
         getInternalState(getState()).enter(event, transition, getContext());
 
-        getTransitionListeners().forEach(l -> l.stateTransition(event, transition));
+        getTransitionListeners().forEach(l -> l.stateTransition(event, transition, getContext()));
         return Optional.of(transition);
     }
 }

--- a/src/main/java/com/bnorm/fsm4j/StateMachineBase.java
+++ b/src/main/java/com/bnorm/fsm4j/StateMachineBase.java
@@ -18,7 +18,7 @@ import java.util.Set;
 public class StateMachineBase<S, E, C> implements StateMachine<S, E, C> {
 
     /** The state machine transition listeners. */
-    private final Set<TransitionListener<? super S, ? super E>> listeners;
+    private final Set<TransitionListener<? super S, ? super E, ? super C>> listeners;
 
     /** The state to internal state map. */
     private final Map<S, InternalState<S, E, C>> states;
@@ -75,12 +75,12 @@ public class StateMachineBase<S, E, C> implements StateMachine<S, E, C> {
     }
 
     @Override
-    public Set<TransitionListener<? super S, ? super E>> getTransitionListeners() {
+    public Set<TransitionListener<? super S, ? super E, ? super C>> getTransitionListeners() {
         return Collections.unmodifiableSet(listeners);
     }
 
     @Override
-    public void addTransitionListener(TransitionListener<? super S, ? super E> listener) {
+    public void addTransitionListener(TransitionListener<? super S, ? super E, ? super C> listener) {
         listeners.add(listener);
     }
 }

--- a/src/main/java/com/bnorm/fsm4j/TransitionListener.java
+++ b/src/main/java/com/bnorm/fsm4j/TransitionListener.java
@@ -5,18 +5,20 @@ package com.bnorm.fsm4j;
  *
  * @param <S> the class type of the states.
  * @param <E> the class type of the events.
+ * @param <C> the class type of the context.
  * @author Brian Norman
  * @version 1.0
  * @since 1.0
  */
 @FunctionalInterface
-public interface TransitionListener<S, E> {
+public interface TransitionListener<S, E, C> {
 
     /**
      * When the listener is added to a state machine, this method is called whenever there is a state transition.
      *
      * @param event the event that caused the transition.
      * @param transition the state transition that took place.
+     * @param context the state machine context.
      */
-    void stateTransition(E event, Transition<? extends S> transition);
+    void stateTransition(E event, Transition<? extends S> transition, C context);
 }


### PR DESCRIPTION
Fixes #33

The transition listeners previously did not have access to the state
machine context.  Any behavior that is performed by the state machine
should have access to the state machine context.
