### PR TITLE
Transitions should have guards

### DIFF
--- a/src/main/java/com/bnorm/fsm4j/Action.java
+++ b/src/main/java/com/bnorm/fsm4j/Action.java
@@ -24,5 +24,5 @@ public interface Action<S, E, C> {
      * @param transition the exact transition taking place.
      * @param context the state machine context.
      */
-    void perform(S state, E event, Transition<? extends S> transition, C context);
+    void perform(S state, E event, Transition<? extends S, ? extends C> transition, C context);
 }

--- a/src/main/java/com/bnorm/fsm4j/InternalState.java
+++ b/src/main/java/com/bnorm/fsm4j/InternalState.java
@@ -106,7 +106,7 @@ public interface InternalState<S, E, C> {
      * @param transition the resulting state transition.
      * @param context the state machine context.
      */
-    default void enter(E event, Transition<S> transition, C context) {
+    default void enter(E event, Transition<S, C> transition, C context) {
         if (transition.isReentrant()) {
             getEntranceActions().stream().forEach(a -> a.perform(getState(), event, transition, context));
         } else if (!isChild(transition.getSource()) && !getState().equals(transition.getSource())) {
@@ -138,7 +138,7 @@ public interface InternalState<S, E, C> {
      * @param transition the resulting state transition.
      * @param context the state machine context.
      */
-    default void exit(E event, Transition<S> transition, C context) {
+    default void exit(E event, Transition<S, C> transition, C context) {
         if (transition.isReentrant()) {
             getExitActions().stream().forEach(a -> a.perform(getState(), event, transition, context));
         } else if (!isChild(transition.getDestination()) && !getState().equals(transition.getDestination())) {

--- a/src/main/java/com/bnorm/fsm4j/StateMachineBase.java
+++ b/src/main/java/com/bnorm/fsm4j/StateMachineBase.java
@@ -24,7 +24,7 @@ public class StateMachineBase<S, E, C> implements StateMachine<S, E, C> {
     private final Map<S, InternalState<S, E, C>> states;
 
     /** The event to transition map. */
-    private final Map<E, Set<Transition<S>>> transitions;
+    private final Map<E, Set<Transition<S, C>>> transitions;
 
     /** The current state of the state machine. */
     private S state;
@@ -40,7 +40,7 @@ public class StateMachineBase<S, E, C> implements StateMachine<S, E, C> {
      * @param starting the starting state of the state machine.
      * @param context the state machine context.
      */
-    protected StateMachineBase(Map<S, InternalState<S, E, C>> states, Map<E, Set<Transition<S>>> transitions,
+    protected StateMachineBase(Map<S, InternalState<S, E, C>> states, Map<E, Set<Transition<S, C>>> transitions,
                                S starting, C context) {
         this.listeners = new LinkedHashSet<>();
         this.states = states;
@@ -70,7 +70,7 @@ public class StateMachineBase<S, E, C> implements StateMachine<S, E, C> {
     }
 
     @Override
-    public Set<Transition<S>> getTransitions(E event) {
+    public Set<Transition<S, C>> getTransitions(E event) {
         return Collections.unmodifiableSet(transitions.getOrDefault(event, Collections.emptySet()));
     }
 

--- a/src/main/java/com/bnorm/fsm4j/StateMachineFactory.java
+++ b/src/main/java/com/bnorm/fsm4j/StateMachineFactory.java
@@ -34,5 +34,5 @@ public interface StateMachineFactory {
      * @return a state machine.
      */
     <S, E, C> StateMachine<S, E, C> create(Map<S, InternalState<S, E, C>> states,
-                                           Map<E, Set<Transition<S>>> transitions, S starting, C context);
+                                           Map<E, Set<Transition<S, C>>> transitions, S starting, C context);
 }

--- a/src/main/java/com/bnorm/fsm4j/Transition.java
+++ b/src/main/java/com/bnorm/fsm4j/Transition.java
@@ -4,11 +4,12 @@ package com.bnorm.fsm4j;
  * Simple interface that represents a transition between states.
  *
  * @param <S> the class type of the states.
+ * @param <C> the class type of the context.
  * @author Brian Norman
  * @version 1.0
  * @since 1.0
  */
-public interface Transition<S> {
+public interface Transition<S, C> {
 
     /**
      * The state the transition originates from.
@@ -35,12 +36,12 @@ public interface Transition<S> {
     }
 
     /**
-     * If the transition is allowed.  This value could change given circumstances outside of the state machine so it is
-     * checked every time this is a possible transition.
+     * Returns the guard for the transition.  If the transition is not guarded, a transition guard that always allows
+     * the transition should be returned.
      *
-     * @return if the transition is currently allowed.
+     * @return the transition guard.
      */
-    default boolean allowed() {
-        return true;
+    default TransitionGuard<C> getGuard() {
+        return TransitionGuard.none();
     }
 }

--- a/src/main/java/com/bnorm/fsm4j/TransitionBase.java
+++ b/src/main/java/com/bnorm/fsm4j/TransitionBase.java
@@ -1,17 +1,15 @@
 package com.bnorm.fsm4j;
 
-import java.util.Optional;
-import java.util.function.BooleanSupplier;
-
 /**
  * The base implementation of a transition.
  *
  * @param <S> the class type of the states.
+ * @param <C> the class type of the context.
  * @author Brian Norman
  * @version 1.0
  * @since 1.0
  */
-public class TransitionBase<S> implements Transition<S> {
+public class TransitionBase<S, C> implements Transition<S, C> {
 
     /** The source state of the transition. */
     private final S source;
@@ -20,41 +18,19 @@ public class TransitionBase<S> implements Transition<S> {
     private final S destination;
 
     /** The conditional nature of the transition. */
-    private final Optional<BooleanSupplier> conditional;
+    private final TransitionGuard<C> guard;
 
     /**
-     * Constructs a new transition from the specified source and destination states.
+     * Constructs a new transition from the specified source and destination states and the transition guard.
      *
      * @param source the source state of the transition.
      * @param destination the destination state of the transition.
+     * @param guard the guard for the transition.
      */
-    protected TransitionBase(S source, S destination) {
-        this(source, destination, Optional.empty());
-    }
-
-    /**
-     * Constructs a new transition from the specified source and destination states and the conditional supplier.
-     *
-     * @param source the source state of the transition.
-     * @param destination the destination state of the transition.
-     * @param conditional the conditional nature of the transition.
-     */
-    protected TransitionBase(S source, S destination, BooleanSupplier conditional) {
-        this(source, destination, Optional.of(conditional));
-    }
-
-    /**
-     * Constructs a new transition from the specified source and destination states and the optional conditional
-     * supplier.
-     *
-     * @param source the source state of the transition.
-     * @param destination the destination state of the transition.
-     * @param conditional the conditional nature of the transition.
-     */
-    protected TransitionBase(S source, S destination, Optional<BooleanSupplier> conditional) {
+    protected TransitionBase(S source, S destination, TransitionGuard<C> guard) {
         this.source = source;
         this.destination = destination;
-        this.conditional = conditional;
+        this.guard = guard;
     }
 
     @Override
@@ -68,8 +44,8 @@ public class TransitionBase<S> implements Transition<S> {
     }
 
     @Override
-    public boolean allowed() {
-        return !conditional.isPresent() || conditional.get().getAsBoolean();
+    public TransitionGuard<C> getGuard() {
+        return guard;
     }
 
     @Override

--- a/src/main/java/com/bnorm/fsm4j/TransitionFactory.java
+++ b/src/main/java/com/bnorm/fsm4j/TransitionFactory.java
@@ -1,8 +1,5 @@
 package com.bnorm.fsm4j;
 
-import java.util.Optional;
-import java.util.function.BooleanSupplier;
-
 /**
  * @author Brian Norman
  * @version 1.0
@@ -25,33 +22,22 @@ public interface TransitionFactory {
      * @param source the source state of the transition.
      * @param destination the destination state of the transition.
      * @param <S> the class type of the states.
+     * @param <C> the class type of the context.
      * @return a transition.
      */
-    default <S> TransitionBase<S> create(S source, S destination) {
-        return create(source, destination, Optional.empty());
+    default <S, C> TransitionBase<S, C> create(S source, S destination) {
+        return create(source, destination, TransitionGuard.none());
     }
 
     /**
-     * Creates a transition from the specified source and destination states and the conditional supplier.
+     * Creates a transition from the specified source and destination states and the transition guard.
      *
      * @param source the source state of the transition.
      * @param destination the destination state of the transition.
-     * @param conditional the conditional nature of the transition.
+     * @param guard the guard for the transition.
      * @param <S> the class type of the states.
+     * @param <C> the class type of the context.
      * @return a transition.
      */
-    default <S> TransitionBase<S> create(S source, S destination, BooleanSupplier conditional) {
-        return create(source, destination, Optional.of(conditional));
-    }
-
-    /**
-     * Creates a transition from the specified source and destination states and the optional conditional supplier.
-     *
-     * @param source the source state of the transition.
-     * @param destination the destination state of the transition.
-     * @param conditional the conditional nature of the transition.
-     * @param <S> the class type of the states.
-     * @return a transition.
-     */
-    <S> TransitionBase<S> create(S source, S destination, Optional<BooleanSupplier> conditional);
+    <S, C> TransitionBase<S, C> create(S source, S destination, TransitionGuard<C> guard);
 }

--- a/src/main/java/com/bnorm/fsm4j/TransitionGuard.java
+++ b/src/main/java/com/bnorm/fsm4j/TransitionGuard.java
@@ -1,0 +1,39 @@
+package com.bnorm.fsm4j;
+
+/**
+ * Simple interface that represents a transition guard.
+ *
+ * @param <C> the class type of the context.
+ * @author Brian Norman
+ * @version 1.0
+ * @since 1.0
+ */
+@FunctionalInterface
+public interface TransitionGuard<C> {
+
+    /**
+     * A transition guard that always allows the transition.  Since this guard always returns true, it can be safely
+     * cast to any required state machine context type.
+     */
+    static TransitionGuard<?> NONE = context -> true;
+
+    /**
+     * Returns the {@link TransitionGuard#NONE} transition guard cast to the required parameter type.
+     *
+     * @param <C> the class type of the context.
+     * @return a type safe {@link TransitionGuard#NONE} transition guard.
+     */
+    static <C> TransitionGuard<C> none() {
+        @SuppressWarnings("unchecked")
+        TransitionGuard<C> guard = (TransitionGuard<C>) NONE;
+        return guard;
+    }
+
+    /**
+     * If a transition is allowed given the specified state machine context.
+     *
+     * @param context the state machine context.
+     * @return if the transition is currently allowed.
+     */
+    boolean allowed(C context);
+}

--- a/src/main/java/com/bnorm/fsm4j/TransitionListener.java
+++ b/src/main/java/com/bnorm/fsm4j/TransitionListener.java
@@ -20,5 +20,5 @@ public interface TransitionListener<S, E, C> {
      * @param transition the state transition that took place.
      * @param context the state machine context.
      */
-    void stateTransition(E event, Transition<? extends S> transition, C context);
+    void stateTransition(E event, Transition<? extends S, ? extends C> transition, C context);
 }

--- a/src/main/java/com/bnorm/fsm4j/builders/StateBuilder.java
+++ b/src/main/java/com/bnorm/fsm4j/builders/StateBuilder.java
@@ -1,10 +1,9 @@
 package com.bnorm.fsm4j.builders;
 
-import java.util.function.BooleanSupplier;
-
 import com.bnorm.fsm4j.Action;
 import com.bnorm.fsm4j.InternalState;
 import com.bnorm.fsm4j.Transition;
+import com.bnorm.fsm4j.TransitionGuard;
 
 /**
  * Represents a builder of a specific state.  The interface provides methods that add behavior to the state machine.
@@ -63,7 +62,7 @@ public interface StateBuilder<S, E, C> {
      * @param transition the transition that will result because of the event.
      * @return the current state builder for chaining.
      */
-    StateBuilder<S, E, C> handle(E event, Transition<S> transition);
+    StateBuilder<S, E, C> handle(E event, Transition<S, C> transition);
 
     /**
      * Adds a reentrant transition as a possible transition given the specified event.
@@ -87,10 +86,10 @@ public interface StateBuilder<S, E, C> {
      * conditional.
      *
      * @param event the event that will cause the reentrant transition.
-     * @param conditional the conditional nature of the transition.
+     * @param guard the guard for the transition.
      * @return the current state builder for chaining.
      */
-    StateBuilder<S, E, C> handle(E event, BooleanSupplier conditional);
+    StateBuilder<S, E, C> handle(E event, TransitionGuard<C> guard);
 
     /**
      * Adds a transition to the specified state as a possible transition given the specified event and the specified
@@ -98,8 +97,8 @@ public interface StateBuilder<S, E, C> {
      *
      * @param event the event that will cause the transition.
      * @param destination the destination of the transition.
-     * @param conditional the conditional nature of the transition.
+     * @param guard the guard for the transition.
      * @return the current state builder for chaining.
      */
-    StateBuilder<S, E, C> handle(E event, S destination, BooleanSupplier conditional);
+    StateBuilder<S, E, C> handle(E event, S destination, TransitionGuard<C> guard);
 }

--- a/src/main/java/com/bnorm/fsm4j/builders/StateBuilderBase.java
+++ b/src/main/java/com/bnorm/fsm4j/builders/StateBuilderBase.java
@@ -3,13 +3,13 @@ package com.bnorm.fsm4j.builders;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BooleanSupplier;
 
 import com.bnorm.fsm4j.Action;
 import com.bnorm.fsm4j.InternalState;
 import com.bnorm.fsm4j.StateMachineException;
 import com.bnorm.fsm4j.Transition;
 import com.bnorm.fsm4j.TransitionFactory;
+import com.bnorm.fsm4j.TransitionGuard;
 
 /**
  * The base implementation of a state builder.
@@ -27,7 +27,7 @@ public class StateBuilderBase<S, E, C> implements StateBuilder<S, E, C> {
     private final Map<S, InternalState<S, E, C>> states;
 
     /** The state machine event to transition map. */
-    private final Map<E, Set<Transition<S>>> transitions;
+    private final Map<E, Set<Transition<S, C>>> transitions;
 
     /** The internal state being built. */
     private final InternalState<S, E, C> state;
@@ -45,7 +45,7 @@ public class StateBuilderBase<S, E, C> implements StateBuilder<S, E, C> {
      * @param state the internal state being built.
      */
     protected StateBuilderBase(TransitionFactory transitionFactory, Map<S, InternalState<S, E, C>> states,
-                               Map<E, Set<Transition<S>>> transitions, InternalState<S, E, C> state) {
+                               Map<E, Set<Transition<S, C>>> transitions, InternalState<S, E, C> state) {
         this.states = states;
         this.transitions = transitions;
         this.state = state;
@@ -84,12 +84,12 @@ public class StateBuilderBase<S, E, C> implements StateBuilder<S, E, C> {
     }
 
     @Override
-    public StateBuilderBase<S, E, C> handle(E event, Transition<S> transition) {
+    public StateBuilderBase<S, E, C> handle(E event, Transition<S, C> transition) {
         if (!transition.getSource().equals(getInternalState().getState())) {
             throw new StateMachineException(
                     "Illegal transition source.  Should be [" + getInternalState().getState() + "] Is [" + transition.getSource() + "]");
         }
-        Set<Transition<S>> handlers = transitions.computeIfAbsent(event, e -> new LinkedHashSet<>());
+        Set<Transition<S, C>> handlers = transitions.computeIfAbsent(event, e -> new LinkedHashSet<>());
         handlers.add(transition);
         return this;
     }
@@ -105,13 +105,13 @@ public class StateBuilderBase<S, E, C> implements StateBuilder<S, E, C> {
     }
 
     @Override
-    public StateBuilderBase<S, E, C> handle(E event, BooleanSupplier conditional) {
+    public StateBuilderBase<S, E, C> handle(E event, TransitionGuard<C> guard) {
         return handle(event, transitionFactory.create(getInternalState().getState(), getInternalState().getState(),
-                                                      conditional));
+                                                      guard));
     }
 
     @Override
-    public StateBuilderBase<S, E, C> handle(E event, S destination, BooleanSupplier conditional) {
-        return handle(event, transitionFactory.create(getInternalState().getState(), destination, conditional));
+    public StateBuilderBase<S, E, C> handle(E event, S destination, TransitionGuard<C> guard) {
+        return handle(event, transitionFactory.create(getInternalState().getState(), destination, guard));
     }
 }

--- a/src/main/java/com/bnorm/fsm4j/builders/StateBuilderFactory.java
+++ b/src/main/java/com/bnorm/fsm4j/builders/StateBuilderFactory.java
@@ -39,5 +39,5 @@ public interface StateBuilderFactory {
      * @return a new state builder.
      */
     <S, E, C> StateBuilder<S, E, C> create(TransitionFactory transitionFactory, Map<S, InternalState<S, E, C>> states,
-                                           Map<E, Set<Transition<S>>> transitions, InternalState<S, E, C> state);
+                                           Map<E, Set<Transition<S, C>>> transitions, InternalState<S, E, C> state);
 }

--- a/src/main/java/com/bnorm/fsm4j/builders/StateMachineBuilderBase.java
+++ b/src/main/java/com/bnorm/fsm4j/builders/StateMachineBuilderBase.java
@@ -39,7 +39,7 @@ public class StateMachineBuilderBase<S, E, C> implements StateMachineBuilder<S, 
     private final Map<S, InternalState<S, E, C>> states;
 
     /** The event to transition map. */
-    private final Map<E, Set<Transition<S>>> transitions;
+    private final Map<E, Set<Transition<S, C>>> transitions;
 
 
     /**


### PR DESCRIPTION
Fixes #32 

The Transition.allowed() method has been refactored into a
TransitionGuard interface that also requires that the state machine
context be provided.  This allows the transition guard to be based off
of the current state machine context.
