### PR TITLE
Making generics parameters at the factory level

### DIFF
--- a/src/main/java/com/bnorm/infinite/InternalStateFactory.java
+++ b/src/main/java/com/bnorm/infinite/InternalStateFactory.java
@@ -7,7 +7,7 @@ package com.bnorm.infinite;
  * @param <E> the class type of the events.
  * @param <C> the class type of the context.
  * @author Brian Norman
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 public interface InternalStateFactory<S, E, C> {

--- a/src/main/java/com/bnorm/infinite/StateMachineFactory.java
+++ b/src/main/java/com/bnorm/infinite/StateMachineFactory.java
@@ -10,7 +10,7 @@ import java.util.Set;
  * @param <E> the class type of the events.
  * @param <C> the class type of the context.
  * @author Brian Norman
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 public interface StateMachineFactory<S, E, C> {

--- a/src/main/java/com/bnorm/infinite/TransitionFactory.java
+++ b/src/main/java/com/bnorm/infinite/TransitionFactory.java
@@ -6,7 +6,7 @@ package com.bnorm.infinite;
  * @param <S> the class type of the states.
  * @param <C> the class type of the context.
  * @author Brian Norman
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 public interface TransitionFactory<S, C> {

--- a/src/main/java/com/bnorm/infinite/builders/StateBuilderBase.java
+++ b/src/main/java/com/bnorm/infinite/builders/StateBuilderBase.java
@@ -18,7 +18,7 @@ import com.bnorm.infinite.TransitionGuard;
  * @param <E> the class type of the events.
  * @param <C> the class type of the context.
  * @author Brian Norman
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 public class StateBuilderBase<S, E, C> implements StateBuilder<S, E, C> {

--- a/src/main/java/com/bnorm/infinite/builders/StateBuilderFactory.java
+++ b/src/main/java/com/bnorm/infinite/builders/StateBuilderFactory.java
@@ -14,7 +14,7 @@ import com.bnorm.infinite.TransitionFactory;
  * @param <E> the class type of the events.
  * @param <C> the class type of the context.
  * @author Brian Norman
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 public interface StateBuilderFactory<S, E, C> {

--- a/src/main/java/com/bnorm/infinite/builders/StateMachineBuilderBase.java
+++ b/src/main/java/com/bnorm/infinite/builders/StateMachineBuilderBase.java
@@ -18,7 +18,7 @@ import com.bnorm.infinite.TransitionFactory;
  * @param <E> the class type of the events.
  * @param <C> the class type of the context.
  * @author Brian Norman
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 public class StateMachineBuilderBase<S, E, C> implements StateMachineBuilder<S, E, C> {

--- a/src/main/java/com/bnorm/infinite/builders/StateMachineBuilderFactory.java
+++ b/src/main/java/com/bnorm/infinite/builders/StateMachineBuilderFactory.java
@@ -11,7 +11,7 @@ import com.bnorm.infinite.TransitionFactory;
  * @param <E> the class type of the events.
  * @param <C> the class type of the context.
  * @author Brian Norman
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 public interface StateMachineBuilderFactory<S, E, C> {


### PR DESCRIPTION
Fixes #45 

Before, generic type parameters were at the method level.  This allowed
a single factory to create objects with any type parameters.  This also,
however, required every factory to be able to create objects with any
type parameters.  Certain use cases will need the ability to limit the
type of objects returned so the parameters need to be at the factory
level instead.
