### PR TITLE
Created factory for asynchronous actions

### DIFF
--- a/src/main/java/com/bnorm/infinite/async/AsyncActionFactory.java
+++ b/src/main/java/com/bnorm/infinite/async/AsyncActionFactory.java
@@ -31,7 +31,7 @@ public interface AsyncActionFactory<S, E, C> {
         return new AsyncActionFactory<S, E, C>() {
             /** The backing executor. */
             private final ExecutorService executor = Executors.newCachedThreadPool(
-                    new ActionThreadFactory("AsyncAction"));
+                    new NamedThreadFactory("AsyncAction"));
 
             @Override
             public ExecutorService getExecutor() {

--- a/src/main/java/com/bnorm/infinite/async/NamedThreadFactory.java
+++ b/src/main/java/com/bnorm/infinite/async/NamedThreadFactory.java
@@ -3,13 +3,13 @@ package com.bnorm.infinite.async;
 import java.util.concurrent.ThreadFactory;
 
 /**
- * A factory interface for action threads.
+ * A factory interface for named threads.
  *
  * @author Brian Norman
  * @version 1.1.0
  * @since 1.1.0
  */
-public class ActionThreadFactory implements ThreadFactory {
+public class NamedThreadFactory implements ThreadFactory {
 
     /** The name used for all threads. */
     private final String name;
@@ -18,15 +18,16 @@ public class ActionThreadFactory implements ThreadFactory {
     private int counter;
 
     /**
-     * Constructs a new action thread factory with the give thread name.
+     * Constructs a new named thread factory with the give thread name.
      *
      * @param name the name to use for all threads.
      */
-    protected ActionThreadFactory(String name) {
+    protected NamedThreadFactory(String name) {
         this.name = name;
         this.counter = -1;
     }
 
+    @Override
     public Thread newThread(Runnable r) {
         counter++;
         return new Thread(r, name + "[" + counter + "]");


### PR DESCRIPTION
Fixes #54

The async action factory can be used to convert actions to be run
asynchronously by the factory's executor.  This functionality could also
be integrated into a state builder so the builder could convert the
actions.
