### PR TITLE
Protection from a null state

### DIFF
--- a/src/main/java/com/bnorm/infinite/InternalState.java
+++ b/src/main/java/com/bnorm/infinite/InternalState.java
@@ -1,5 +1,6 @@
 package com.bnorm.infinite;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -48,7 +49,7 @@ public interface InternalState<S, E, C> {
     default boolean isParent(S state) {
         if (getParentState().isPresent()) {
             InternalState<S, E, C> parent = getParentState().get();
-            return parent.getState().equals(state) || parent.isParent(state);
+            return Objects.equals(parent.getState(), state) || parent.isParent(state);
         } else {
             return false;
         }
@@ -78,7 +79,7 @@ public interface InternalState<S, E, C> {
      */
     default boolean isChild(S state) {
         // Check all children...
-        return getChildrenStates().stream().anyMatch(c -> c.getState().equals(state))
+        return getChildrenStates().stream().anyMatch(c -> Objects.equals(c.getState(), state))
                 // ... before checking recursion to check children's children.
                 || getChildrenStates().parallelStream().anyMatch(c -> c.isChild(state));
     }
@@ -109,7 +110,7 @@ public interface InternalState<S, E, C> {
     default void enter(E event, Transition<S, C> transition, C context) {
         if (transition.isReentrant()) {
             getEntranceActions().stream().forEach(a -> a.perform(getState(), event, transition, context));
-        } else if (!isChild(transition.getSource()) && !getState().equals(transition.getSource())) {
+        } else if (!isChild(transition.getSource()) && !Objects.equals(getState(), transition.getSource())) {
             getParentState().ifPresent(s -> s.enter(event, transition, context));
             getEntranceActions().stream().forEach(a -> a.perform(getState(), event, transition, context));
         }
@@ -141,7 +142,7 @@ public interface InternalState<S, E, C> {
     default void exit(E event, Transition<S, C> transition, C context) {
         if (transition.isReentrant()) {
             getExitActions().stream().forEach(a -> a.perform(getState(), event, transition, context));
-        } else if (!isChild(transition.getDestination()) && !getState().equals(transition.getDestination())) {
+        } else if (!isChild(transition.getDestination()) && !Objects.equals(getState(), transition.getDestination())) {
             getExitActions().stream().forEach(a -> a.perform(getState(), event, transition, context));
             getParentState().ifPresent(s -> s.exit(event, transition, context));
         }

--- a/src/main/java/com/bnorm/infinite/StateMachineBase.java
+++ b/src/main/java/com/bnorm/infinite/StateMachineBase.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -83,7 +84,7 @@ public class StateMachineBase<S, E, C> implements StateMachine<S, E, C> {
         while (possible.isEmpty() && optional.isPresent()) {
             final InternalState<S, E, C> state = optional.get();
             possible = eventTransitions.stream()
-                                       .filter(t -> t.getSource().equals(state.getState()))
+                                       .filter(t -> Objects.equals(t.getSource(), state.getState()))
                                        .filter(t -> t.getGuard().allowed(getContext()))
                                        .collect(Collectors.toList());
             optional = state.getParentState();

--- a/src/main/java/com/bnorm/infinite/Transition.java
+++ b/src/main/java/com/bnorm/infinite/Transition.java
@@ -1,5 +1,7 @@
 package com.bnorm.infinite;
 
+import java.util.Objects;
+
 /**
  * Simple interface that represents a transition between states.
  *
@@ -32,7 +34,7 @@ public interface Transition<S, C> {
      * @return if the source state is equal to the destination state.
      */
     default boolean isReentrant() {
-        return getSource().equals(getDestination());
+        return Objects.equals(getSource(), getDestination());
     }
 
     /**

--- a/src/main/java/com/bnorm/infinite/builders/StateBuilderBase.java
+++ b/src/main/java/com/bnorm/infinite/builders/StateBuilderBase.java
@@ -2,6 +2,7 @@ package com.bnorm.infinite.builders;
 
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -86,7 +87,7 @@ public class StateBuilderBase<S, E, C> implements StateBuilder<S, E, C> {
 
     @Override
     public StateBuilderBase<S, E, C> handle(E event, Transition<S, C> transition) {
-        if (!transition.getSource().equals(getInternalState().getState())) {
+        if (!Objects.equals(transition.getSource(), getInternalState().getState())) {
             throw new StateMachineException(
                     "Illegal transition source.  Should be [" + getInternalState().getState() + "] Is [" + transition.getSource() + "]");
         }


### PR DESCRIPTION
Fixes #61 

Starting a state machine in a null state is a quick and dirty way for
the state machine to perform some starting action when it enters the
very first state.
