### PR TITLE
Adding transition action

### DIFF
--- a/src/main/java/com/bnorm/infinite/Action.java
+++ b/src/main/java/com/bnorm/infinite/Action.java
@@ -39,10 +39,10 @@ public interface Action<S, E, C> {
      * state being entered or existed is not a part of the specific transition - it might be a parent state of the
      * source or destination.
      *
-     * @param state the state being entered or exited.
+     * @param state the state being entered or exited or the common ancestor of the state.
      * @param event the event causing the transition.
      * @param transition the exact transition taking place.
      * @param context the state machine context.
      */
-    void perform(S state, E event, Transition<? extends S, ? extends C> transition, C context);
+    void perform(S state, E event, Transition<? extends S, ? extends E, ? extends C> transition, C context);
 }

--- a/src/main/java/com/bnorm/infinite/InternalState.java
+++ b/src/main/java/com/bnorm/infinite/InternalState.java
@@ -106,7 +106,7 @@ public interface InternalState<S, E, C> {
      * @param transition the resulting state transition.
      * @param context the state machine context.
      */
-    default void enter(E event, Transition<S, C> transition, C context) {
+    default void enter(E event, Transition<? extends S, ? extends E, ? extends C> transition, C context) {
         if (transition.isReentrant()) {
             getEntranceActions().stream().forEach(a -> a.perform(getState(), event, transition, context));
         } else if (!isChild(transition.getSource()) && !Objects.equals(getState(), transition.getSource())) {
@@ -138,7 +138,7 @@ public interface InternalState<S, E, C> {
      * @param transition the resulting state transition.
      * @param context the state machine context.
      */
-    default void exit(E event, Transition<S, C> transition, C context) {
+    default void exit(E event, Transition<? extends S, ? extends E, ? extends C> transition, C context) {
         if (transition.isReentrant()) {
             getExitActions().stream().forEach(a -> a.perform(getState(), event, transition, context));
         } else if (!isChild(transition.getDestination()) && !Objects.equals(getState(), transition.getDestination())) {

--- a/src/main/java/com/bnorm/infinite/StateMachine.java
+++ b/src/main/java/com/bnorm/infinite/StateMachine.java
@@ -40,5 +40,5 @@ public interface StateMachine<S, E, C> {
      * @param event the event fired.
      * @return the resulting transition.
      */
-    Optional<Transition<S, C>> fire(E event);
+    Optional<Transition<S, E, C>> fire(E event);
 }

--- a/src/main/java/com/bnorm/infinite/StateMachineStructure.java
+++ b/src/main/java/com/bnorm/infinite/StateMachineStructure.java
@@ -38,7 +38,7 @@ public interface StateMachineStructure<S, E, C> {
      *
      * @return the transition factory.
      */
-    TransitionFactory<S, C> getTransitionFactory();
+    TransitionFactory<S, E, C> getTransitionFactory();
 
     /**
      * Returns the transitions associated with the specified event.  This method should never return a {@code null} set
@@ -47,7 +47,7 @@ public interface StateMachineStructure<S, E, C> {
      * @param event the state machine event.
      * @return the associated transitions.
      */
-    Set<Transition<S, C>> getTransitions(E event);
+    Set<Transition<S, E, C>> getTransitions(E event);
 
     /**
      * Adds the specified transition as a possible transition for the specified event.
@@ -55,5 +55,5 @@ public interface StateMachineStructure<S, E, C> {
      * @param event the state machine event.
      * @param transition the event transition.
      */
-    void addTransition(E event, Transition<S, C> transition);
+    void addTransition(E event, Transition<S, E, C> transition);
 }

--- a/src/main/java/com/bnorm/infinite/StateMachineStructureBase.java
+++ b/src/main/java/com/bnorm/infinite/StateMachineStructureBase.java
@@ -9,9 +9,9 @@ import java.util.Set;
 /**
  * The base implementation of a state machine structure.
  *
- * @param <S>
- * @param <E>
- * @param <C>
+ * @param <S> the class type of the states.
+ * @param <E> the class type of the events.
+ * @param <C> the class type of the context.
  * @author Brian Norman
  * @since 1.1.0
  */
@@ -21,13 +21,13 @@ public class StateMachineStructureBase<S, E, C> implements StateMachineStructure
     private final InternalStateFactory<S, E, C> internalStateFactory;
 
     /** The state transition factory. */
-    private final TransitionFactory<S, C> transitionFactory;
+    private final TransitionFactory<S, E, C> transitionFactory;
 
     /** The state to internal state map. */
     private final Map<S, InternalState<S, E, C>> states;
 
     /** The event to transition map. */
-    private final Map<E, Set<Transition<S, C>>> transitions;
+    private final Map<E, Set<Transition<S, E, C>>> transitions;
 
     /**
      * Constructs a new state machine structure base from the specified internal state factory and transition factory.
@@ -36,7 +36,7 @@ public class StateMachineStructureBase<S, E, C> implements StateMachineStructure
      * @param transitionFactory the factory used to create transitions.
      */
     protected StateMachineStructureBase(InternalStateFactory<S, E, C> internalStateFactory,
-                                        TransitionFactory<S, C> transitionFactory) {
+                                        TransitionFactory<S, E, C> transitionFactory) {
         this.internalStateFactory = internalStateFactory;
         this.transitionFactory = transitionFactory;
         this.states = Collections.synchronizedMap(new HashMap<>());
@@ -54,17 +54,17 @@ public class StateMachineStructureBase<S, E, C> implements StateMachineStructure
     }
 
     @Override
-    public TransitionFactory<S, C> getTransitionFactory() {
+    public TransitionFactory<S, E, C> getTransitionFactory() {
         return transitionFactory;
     }
 
     @Override
-    public Set<Transition<S, C>> getTransitions(E event) {
+    public Set<Transition<S, E, C>> getTransitions(E event) {
         return Collections.unmodifiableSet(getTransitionsUnsafe(event));
     }
 
     @Override
-    public void addTransition(E event, Transition<S, C> transition) {
+    public void addTransition(E event, Transition<S, E, C> transition) {
         getTransitionsUnsafe(event).add(transition);
     }
 
@@ -74,7 +74,7 @@ public class StateMachineStructureBase<S, E, C> implements StateMachineStructure
      * @param event the state machine event.
      * @return the associated transitions.
      */
-    private Set<Transition<S, C>> getTransitionsUnsafe(E event) {
+    private Set<Transition<S, E, C>> getTransitionsUnsafe(E event) {
         return transitions.computeIfAbsent(event, e -> Collections.synchronizedSet(new HashSet<>()));
     }
 }

--- a/src/main/java/com/bnorm/infinite/StateMachineStructureFactory.java
+++ b/src/main/java/com/bnorm/infinite/StateMachineStructureFactory.java
@@ -3,9 +3,9 @@ package com.bnorm.infinite;
 /**
  * A factory interface for state machine structures.
  *
- * @param <S>
- * @param <E>
- * @param <C>
+ * @param <S> the class type of the states.
+ * @param <E> the class type of the events.
+ * @param <C> the class type of the context.
  * @author Brian Norman
  * @since 1.1.0
  */
@@ -45,5 +45,5 @@ public interface StateMachineStructureFactory<S, E, C> {
      * @return a new state machine structure.
      */
     StateMachineStructure<S, E, C> create(InternalStateFactory<S, E, C> internalStateFactory,
-                                          TransitionFactory<S, C> transitionFactory);
+                                          TransitionFactory<S, E, C> transitionFactory);
 }

--- a/src/main/java/com/bnorm/infinite/Transition.java
+++ b/src/main/java/com/bnorm/infinite/Transition.java
@@ -6,11 +6,12 @@ import java.util.Objects;
  * Simple interface that represents a transition between states.
  *
  * @param <S> the class type of the states.
+ * @param <E> the class type of the events.
  * @param <C> the class type of the context.
  * @author Brian Norman
  * @since 1.0.0
  */
-public interface Transition<S, C> {
+public interface Transition<S, E, C> {
 
     /**
      * The state the transition originates from.
@@ -44,5 +45,15 @@ public interface Transition<S, C> {
      */
     default TransitionGuard<C> getGuard() {
         return TransitionGuard.none();
+    }
+
+    /**
+     * Returns the action to perform during the transition.  If the transition does not of an action, a transition
+     * action that performs no action should be returned.
+     *
+     * @return the transition action.
+     */
+    default Action<S, E, C> getAction() {
+        return Action.noAction();
     }
 }

--- a/src/main/java/com/bnorm/infinite/TransitionBase.java
+++ b/src/main/java/com/bnorm/infinite/TransitionBase.java
@@ -6,11 +6,12 @@ import java.util.function.Supplier;
  * The base implementation of a transition.
  *
  * @param <S> the class type of the states.
+ * @param <E> the class type of the events.
  * @param <C> the class type of the context.
  * @author Brian Norman
  * @since 1.0.0
  */
-public class TransitionBase<S, C> implements Transition<S, C> {
+public class TransitionBase<S, E, C> implements Transition<S, E, C> {
 
     /** The source state of the transition. */
     private final S source;
@@ -21,17 +22,22 @@ public class TransitionBase<S, C> implements Transition<S, C> {
     /** The conditional nature of the transition. */
     private final TransitionGuard<C> guard;
 
+    /** The action to perform during the transition. */
+    private final Action<S, E, C> action;
+
     /**
      * Constructs a new transition from the specified source and destination states and the transition guard.
      *
      * @param source the source state of the transition.
      * @param destination the destination state supplier of the transition.
      * @param guard the guard for the transition.
+     * @param action the action to perform during the transition.
      */
-    protected TransitionBase(S source, Supplier<S> destination, TransitionGuard<C> guard) {
+    protected TransitionBase(S source, Supplier<S> destination, TransitionGuard<C> guard, Action<S, E, C> action) {
         this.source = source;
         this.destination = destination;
         this.guard = guard;
+        this.action = action;
     }
 
     @Override
@@ -47,6 +53,11 @@ public class TransitionBase<S, C> implements Transition<S, C> {
     @Override
     public TransitionGuard<C> getGuard() {
         return guard;
+    }
+
+    @Override
+    public Action<S, E, C> getAction() {
+        return action;
     }
 
     @Override

--- a/src/main/java/com/bnorm/infinite/TransitionFactory.java
+++ b/src/main/java/com/bnorm/infinite/TransitionFactory.java
@@ -6,11 +6,12 @@ import java.util.function.Supplier;
  * A factory interface for transitions.
  *
  * @param <S> the class type of the states.
+ * @param <E> the class type of the events.
  * @param <C> the class type of the context.
  * @author Brian Norman
  * @since 1.0.0
  */
-public interface TransitionFactory<S, C> {
+public interface TransitionFactory<S, E, C> {
 
     /**
      * Returns the default internal state factory.  This is the internal state base constructor.
@@ -19,7 +20,7 @@ public interface TransitionFactory<S, C> {
      * @param <C> the class type of the context.
      * @return default internal state factory.
      */
-    static <S, C> TransitionFactory<S, C> getDefault() {
+    static <S, E, C> TransitionFactory<S, E, C> getDefault() {
         return TransitionBase::new;
     }
 
@@ -31,8 +32,8 @@ public interface TransitionFactory<S, C> {
      * @param transition the transition of which to make a snapshot clone.
      * @return a transition.
      */
-    default Transition<S, C> create(Transition<S, C> transition) {
-        return create(transition.getSource(), transition.getDestination());
+    default Transition<S, E, C> create(Transition<S, E, C> transition) {
+        return create(transition.getSource(), transition.getDestination(), transition.getAction());
     }
 
     /**
@@ -42,7 +43,7 @@ public interface TransitionFactory<S, C> {
      * @param destination the destination state of the transition.
      * @return a transition.
      */
-    default Transition<S, C> create(S source, S destination) {
+    default Transition<S, E, C> create(S source, S destination) {
         return create(source, () -> destination);
     }
 
@@ -53,8 +54,8 @@ public interface TransitionFactory<S, C> {
      * @param destination the destination state of the transition.
      * @return a transition.
      */
-    default Transition<S, C> create(S source, Supplier<S> destination) {
-        return create(source, destination, TransitionGuard.none());
+    default Transition<S, E, C> create(S source, Supplier<S> destination) {
+        return create(source, destination, TransitionGuard.none(), Action.noAction());
     }
 
     /**
@@ -65,8 +66,8 @@ public interface TransitionFactory<S, C> {
      * @param guard the guard for the transition.
      * @return a transition.
      */
-    default Transition<S, C> create(S source, S destination, TransitionGuard<C> guard) {
-        return create(source, () -> destination, guard);
+    default Transition<S, E, C> create(S source, S destination, TransitionGuard<C> guard) {
+        return create(source, () -> destination, guard, Action.noAction());
     }
 
     /**
@@ -77,5 +78,57 @@ public interface TransitionFactory<S, C> {
      * @param guard the guard for the transition.
      * @return a transition.
      */
-    Transition<S, C> create(S source, Supplier<S> destination, TransitionGuard<C> guard);
+    default Transition<S, E, C> create(S source, Supplier<S> destination, TransitionGuard<C> guard) {
+        return create(source, destination, guard, Action.noAction());
+    }
+
+    /**
+     * Creates a transition from the specified source and destination states and the transition action.
+     *
+     * @param source the source state of the transition.
+     * @param destination the destination state supplier of the transition.
+     * @param action the action to perform during the transition.
+     * @return a transition.
+     */
+    default Transition<S, E, C> create(S source, S destination, Action<S, E, C> action) {
+        return create(source, () -> destination, action);
+    }
+
+    /**
+     * Creates a transition from the specified source and destination states and the transition action.
+     *
+     * @param source the source state of the transition.
+     * @param destination the destination state supplier of the transition.
+     * @param action the action to perform during the transition.
+     * @return a transition.
+     */
+    default Transition<S, E, C> create(S source, Supplier<S> destination, Action<S, E, C> action) {
+        return create(source, destination, TransitionGuard.none(), action);
+    }
+
+    /**
+     * Creates a transition from the specified source and destination states, the transition guard, and the transition
+     * action.
+     *
+     * @param source the source state of the transition.
+     * @param destination the destination state supplier of the transition.
+     * @param guard the guard for the transition.
+     * @param action the action to perform during the transition.
+     * @return a transition.
+     */
+    default Transition<S, E, C> create(S source, S destination, TransitionGuard<C> guard, Action<S, E, C> action) {
+        return create(source, () -> destination, guard, action);
+    }
+
+    /**
+     * Creates a transition from the specified source and destination states, the transition guard, and the transition
+     * action.
+     *
+     * @param source the source state of the transition.
+     * @param destination the destination state supplier of the transition.
+     * @param guard the guard for the transition.
+     * @param action the action to perform during the transition.
+     * @return a transition.
+     */
+    Transition<S, E, C> create(S source, Supplier<S> destination, TransitionGuard<C> guard, Action<S, E, C> action);
 }

--- a/src/main/java/com/bnorm/infinite/TransitionListener.java
+++ b/src/main/java/com/bnorm/infinite/TransitionListener.java
@@ -20,5 +20,6 @@ public interface TransitionListener<S, E, C> {
      * @param transition the state transition that took place.
      * @param context the state machine context.
      */
-    void stateTransition(TransitionStage stage, E event, Transition<? extends S, ? extends C> transition, C context);
+    void stateTransition(TransitionStage stage, E event, Transition<? extends S, ? extends E, ? extends C> transition,
+                         C context);
 }

--- a/src/main/java/com/bnorm/infinite/async/AsyncActionFactory.java
+++ b/src/main/java/com/bnorm/infinite/async/AsyncActionFactory.java
@@ -35,7 +35,8 @@ public interface AsyncActionFactory<S, E, C> {
             public Action<S, E, C> create(Action<S, E, C> action) {
                 return new Action<S, E, C>() {
                     @Override
-                    public void perform(S state, E event, Transition<? extends S, ? extends C> transition, C context) {
+                    public void perform(S state, E event, Transition<? extends S, ? extends E, ? extends C> transition,
+                                        C context) {
                         executor.submit(() -> action.perform(state, event, transition, context));
                     }
                 };

--- a/src/main/java/com/bnorm/infinite/async/AsyncStateMachine.java
+++ b/src/main/java/com/bnorm/infinite/async/AsyncStateMachine.java
@@ -42,7 +42,7 @@ public interface AsyncStateMachine<S, E, C> extends StateMachine<S, E, C>, Runna
      * @return the resulting transition.
      */
     @Override
-    Optional<Transition<S, C>> fire(E event);
+    Optional<Transition<S, E, C>> fire(E event);
 
     /**
      * Submits the specified event to the state machine to be processed.  This adds the specified event to the end of
@@ -51,7 +51,7 @@ public interface AsyncStateMachine<S, E, C> extends StateMachine<S, E, C>, Runna
      * @param event the event submitted.
      * @return the future of the resulting transition.
      */
-    Future<Optional<Transition<S, C>>> submit(E event);
+    Future<Optional<Transition<S, E, C>>> submit(E event);
 
     /**
      * Injects the specified event to the state machine for immediate processing.  This adds the specified event at the
@@ -60,5 +60,5 @@ public interface AsyncStateMachine<S, E, C> extends StateMachine<S, E, C>, Runna
      * @param event the event injected.
      * @return the future of the resulting transition.
      */
-    Future<Optional<Transition<S, C>>> inject(E event);
+    Future<Optional<Transition<S, E, C>>> inject(E event);
 }

--- a/src/main/java/com/bnorm/infinite/async/AsyncTransitionListenerFactory.java
+++ b/src/main/java/com/bnorm/infinite/async/AsyncTransitionListenerFactory.java
@@ -39,7 +39,8 @@ public interface AsyncTransitionListenerFactory<S, E, C> {
                 return new TransitionListener<S, E, C>() {
                     @Override
                     public void stateTransition(TransitionStage stage, E event,
-                                                Transition<? extends S, ? extends C> transition, C context) {
+                                                Transition<? extends S, ? extends E, ? extends C> transition,
+                                                C context) {
                         executor.submit(() -> listener.stateTransition(stage, event, transition, context));
                     }
                 };

--- a/src/main/java/com/bnorm/infinite/builders/AsyncStateBuilder.java
+++ b/src/main/java/com/bnorm/infinite/builders/AsyncStateBuilder.java
@@ -44,7 +44,7 @@ public interface AsyncStateBuilder<S, E, C> extends StateBuilder<S, E, C> {
     AsyncStateBuilder<S, E, C> onAsyncExit(Action<S, E, C> action);
 
     @Override
-    AsyncStateBuilder<S, E, C> handle(E event, Transition<S, C> transition);
+    AsyncStateBuilder<S, E, C> handle(E event, Transition<S, E, C> transition);
 
     @Override
     AsyncStateBuilder<S, E, C> handle(E event);
@@ -59,8 +59,24 @@ public interface AsyncStateBuilder<S, E, C> extends StateBuilder<S, E, C> {
     AsyncStateBuilder<S, E, C> handle(E event, TransitionGuard<C> guard);
 
     @Override
+    AsyncStateBuilder<S, E, C> handle(E event, Action<S, E, C> action);
+
+    @Override
     AsyncStateBuilder<S, E, C> handle(E event, S destination, TransitionGuard<C> guard);
 
     @Override
     AsyncStateBuilder<S, E, C> handle(E event, Supplier<S> destination, TransitionGuard<C> guard);
+
+    @Override
+    AsyncStateBuilder<S, E, C> handle(E event, S destination, Action<S, E, C> action);
+
+    @Override
+    AsyncStateBuilder<S, E, C> handle(E event, Supplier<S> destination, Action<S, E, C> action);
+
+    @Override
+    AsyncStateBuilder<S, E, C> handle(E event, S destination, TransitionGuard<C> guard, Action<S, E, C> action);
+
+    @Override
+    AsyncStateBuilder<S, E, C> handle(E event, Supplier<S> destination, TransitionGuard<C> guard,
+                                      Action<S, E, C> action);
 }

--- a/src/main/java/com/bnorm/infinite/builders/AsyncStateBuilderBase.java
+++ b/src/main/java/com/bnorm/infinite/builders/AsyncStateBuilderBase.java
@@ -66,7 +66,7 @@ public class AsyncStateBuilderBase<S, E, C> extends StateBuilderBase<S, E, C> im
     }
 
     @Override
-    public AsyncStateBuilderBase<S, E, C> handle(E event, Transition<S, C> transition) {
+    public AsyncStateBuilderBase<S, E, C> handle(E event, Transition<S, E, C> transition) {
         super.handle(event, transition);
         return this;
     }
@@ -96,6 +96,12 @@ public class AsyncStateBuilderBase<S, E, C> extends StateBuilderBase<S, E, C> im
     }
 
     @Override
+    public AsyncStateBuilderBase<S, E, C> handle(E event, Action<S, E, C> action) {
+        super.handle(event, action);
+        return this;
+    }
+
+    @Override
     public AsyncStateBuilderBase<S, E, C> handle(E event, S destination, TransitionGuard<C> guard) {
         super.handle(event, destination, guard);
         return this;
@@ -104,6 +110,32 @@ public class AsyncStateBuilderBase<S, E, C> extends StateBuilderBase<S, E, C> im
     @Override
     public AsyncStateBuilderBase<S, E, C> handle(E event, Supplier<S> destination, TransitionGuard<C> guard) {
         super.handle(event, destination, guard);
+        return this;
+    }
+
+    @Override
+    public AsyncStateBuilderBase<S, E, C> handle(E event, S destination, Action<S, E, C> action) {
+        super.handle(event, destination, action);
+        return this;
+    }
+
+    @Override
+    public AsyncStateBuilderBase<S, E, C> handle(E event, Supplier<S> destination, Action<S, E, C> action) {
+        super.handle(event, destination, action);
+        return this;
+    }
+
+    @Override
+    public AsyncStateBuilderBase<S, E, C> handle(E event, S destination, TransitionGuard<C> guard,
+                                                 Action<S, E, C> action) {
+        super.handle(event, destination, guard, action);
+        return this;
+    }
+
+    @Override
+    public AsyncStateBuilderBase<S, E, C> handle(E event, Supplier<S> destination, TransitionGuard<C> guard,
+                                                 Action<S, E, C> action) {
+        super.handle(event, destination, guard, action);
         return this;
     }
 }

--- a/src/main/java/com/bnorm/infinite/builders/StateBuilder.java
+++ b/src/main/java/com/bnorm/infinite/builders/StateBuilder.java
@@ -49,7 +49,7 @@ public interface StateBuilder<S, E, C> {
      * @param transition the transition that will result because of the event.
      * @return the current state builder for chaining.
      */
-    StateBuilder<S, E, C> handle(E event, Transition<S, C> transition);
+    StateBuilder<S, E, C> handle(E event, Transition<S, E, C> transition);
 
     /**
      * Adds a reentrant transition as a possible transition given the specified event.
@@ -88,6 +88,16 @@ public interface StateBuilder<S, E, C> {
     StateBuilder<S, E, C> handle(E event, TransitionGuard<C> guard);
 
     /**
+     * Adds a transition to the specified state as a possible transition given the specified event and transition
+     * action.
+     *
+     * @param event the event that will cause the transition.
+     * @param action the action to perform during the transition.
+     * @return the current state builder for chaining.
+     */
+    StateBuilder<S, E, C> handle(E event, Action<S, E, C> action);
+
+    /**
      * Adds a transition to the specified state as a possible transition given the specified event, destination, and the
      * transition guard.
      *
@@ -108,4 +118,50 @@ public interface StateBuilder<S, E, C> {
      * @return the current state builder for chaining.
      */
     StateBuilder<S, E, C> handle(E event, Supplier<S> destination, TransitionGuard<C> guard);
+
+    /**
+     * Adds a transition to the specified state as a possible transition given the specified event, destination, and
+     * transition action.
+     *
+     * @param event the event that will cause the transition.
+     * @param destination the destination of the transition.
+     * @param action the action to perform during the transition.
+     * @return the current state builder for chaining.
+     */
+    StateBuilder<S, E, C> handle(E event, S destination, Action<S, E, C> action);
+
+    /**
+     * Adds a transition to the specified state as a possible transition given the specified event, destination
+     * supplier, and transition action.
+     *
+     * @param event the event that will cause the transition.
+     * @param destination the destination supplier of the transition.
+     * @param action the action to perform during the transition.
+     * @return the current state builder for chaining.
+     */
+    StateBuilder<S, E, C> handle(E event, Supplier<S> destination, Action<S, E, C> action);
+
+    /**
+     * Adds a transition to the specified state as a possible transition given the specified event, destination,
+     * transition guard, and transition action.
+     *
+     * @param event the event that will cause the transition.
+     * @param destination the destination of the transition.
+     * @param guard the guard for the transition.
+     * @param action the action to perform during the transition.
+     * @return the current state builder for chaining.
+     */
+    StateBuilder<S, E, C> handle(E event, S destination, TransitionGuard<C> guard, Action<S, E, C> action);
+
+    /**
+     * Adds a transition to the specified state as a possible transition given the specified event, destination
+     * supplier, transition guard, and transition action.
+     *
+     * @param event the event that will cause the transition.
+     * @param destination the destination supplier of the transition.
+     * @param guard the guard for the transition.
+     * @param action the action to perform during the transition.
+     * @return the current state builder for chaining.
+     */
+    StateBuilder<S, E, C> handle(E event, Supplier<S> destination, TransitionGuard<C> guard, Action<S, E, C> action);
 }

--- a/src/main/java/com/bnorm/infinite/builders/StateBuilderBase.java
+++ b/src/main/java/com/bnorm/infinite/builders/StateBuilderBase.java
@@ -60,7 +60,7 @@ public class StateBuilderBase<S, E, C> implements StateBuilder<S, E, C> {
     }
 
     @Override
-    public StateBuilderBase<S, E, C> handle(E event, Transition<S, C> transition) {
+    public StateBuilderBase<S, E, C> handle(E event, Transition<S, E, C> transition) {
         if (!Objects.equals(transition.getSource(), state)) {
             throw new StateMachineException(
                     "Illegal transition source.  Should be [" + state + "] Is [" + transition.getSource() + "]");
@@ -80,7 +80,7 @@ public class StateBuilderBase<S, E, C> implements StateBuilder<S, E, C> {
     }
 
     @Override
-    public StateBuilder<S, E, C> handle(E event, Supplier<S> destination) {
+    public StateBuilderBase<S, E, C> handle(E event, Supplier<S> destination) {
         return handle(event, structure.getTransitionFactory().create(state, destination));
     }
 
@@ -90,12 +90,38 @@ public class StateBuilderBase<S, E, C> implements StateBuilder<S, E, C> {
     }
 
     @Override
+    public StateBuilderBase<S, E, C> handle(E event, Action<S, E, C> action) {
+        return handle(event, structure.getTransitionFactory().create(state, state, action));
+    }
+
+    @Override
     public StateBuilderBase<S, E, C> handle(E event, S destination, TransitionGuard<C> guard) {
         return handle(event, structure.getTransitionFactory().create(state, destination, guard));
     }
 
     @Override
-    public StateBuilder<S, E, C> handle(E event, Supplier<S> destination, TransitionGuard<C> guard) {
+    public StateBuilderBase<S, E, C> handle(E event, Supplier<S> destination, TransitionGuard<C> guard) {
         return handle(event, structure.getTransitionFactory().create(state, destination, guard));
+    }
+
+    @Override
+    public StateBuilderBase<S, E, C> handle(E event, S destination, Action<S, E, C> action) {
+        return handle(event, structure.getTransitionFactory().create(state, destination, action));
+    }
+
+    @Override
+    public StateBuilderBase<S, E, C> handle(E event, Supplier<S> destination, Action<S, E, C> action) {
+        return handle(event, structure.getTransitionFactory().create(state, destination, action));
+    }
+
+    @Override
+    public StateBuilderBase<S, E, C> handle(E event, S destination, TransitionGuard<C> guard, Action<S, E, C> action) {
+        return handle(event, structure.getTransitionFactory().create(state, destination, guard, action));
+    }
+
+    @Override
+    public StateBuilderBase<S, E, C> handle(E event, Supplier<S> destination, TransitionGuard<C> guard,
+                                            Action<S, E, C> action) {
+        return handle(event, structure.getTransitionFactory().create(state, destination, guard, action));
     }
 }

--- a/src/main/java/com/bnorm/infinite/file/FileStateMachineStructureFactory.java
+++ b/src/main/java/com/bnorm/infinite/file/FileStateMachineStructureFactory.java
@@ -39,7 +39,7 @@ public class FileStateMachineStructureFactory<S, E, C> implements StateMachineSt
 
     @Override
     public StateMachineStructure<S, E, C> create(InternalStateFactory<S, E, C> internalStateFactory,
-                                                 TransitionFactory<S, C> transitionFactory) {
+                                                 TransitionFactory<S, E, C> transitionFactory) {
         try {
             return new FileStateMachineStructure<>(internalStateFactory, transitionFactory, path, stateMachineReader);
         } catch (IOException e) {

--- a/src/test/java/com/bnorm/infinite/InternalStateTest.java
+++ b/src/test/java/com/bnorm/infinite/InternalStateTest.java
@@ -295,7 +295,7 @@ public class InternalStateTest {
 
         Action<String, Void, List<String>> action = (s, e, t, c) -> c.add(s);
         List<String> actions = new ArrayList<>();
-        Transition<String, List<String>> transition;
+        Transition<String, Void, List<String>> transition;
 
         grandparent.addEntranceAction(action);
         parent.addEntranceAction(action);
@@ -321,7 +321,8 @@ public class InternalStateTest {
 
         // Reentrant transitions
 
-        transition = new TransitionBase<>(parent.getState(), parent::getState, TransitionGuard.none());
+        transition = new TransitionBase<>(parent.getState(), parent::getState, TransitionGuard.none(),
+                                          Action.noAction());
 
         actions.clear();
         parent.exit(null, transition, actions);
@@ -333,7 +334,8 @@ public class InternalStateTest {
 
         // Child to parent transitions
 
-        transition = new TransitionBase<>(parent.getState(), grandparent::getState, TransitionGuard.none());
+        transition = new TransitionBase<>(parent.getState(), grandparent::getState, TransitionGuard.none(),
+                                          Action.noAction());
 
         actions.clear();
         parent.exit(null, transition, actions);
@@ -343,7 +345,8 @@ public class InternalStateTest {
         grandparent.enter(null, transition, actions);
         Assert.assertEquals(Collections.<String>emptyList(), actions);
 
-        transition = new TransitionBase<>(grandchild4_1.getState(), grandparent::getState, TransitionGuard.none());
+        transition = new TransitionBase<>(grandchild4_1.getState(), grandparent::getState, TransitionGuard.none(),
+                                          Action.noAction());
 
         actions.clear();
         grandchild4_1.exit(null, transition, actions);
@@ -355,7 +358,8 @@ public class InternalStateTest {
 
         // Parent to child transitions
 
-        transition = new TransitionBase<>(grandparent.getState(), parent::getState, TransitionGuard.none());
+        transition = new TransitionBase<>(grandparent.getState(), parent::getState, TransitionGuard.none(),
+                                          Action.noAction());
 
         actions.clear();
         grandparent.exit(null, transition, actions);
@@ -365,7 +369,8 @@ public class InternalStateTest {
         parent.enter(null, transition, actions);
         Assert.assertEquals(Arrays.asList(parent.getState()), actions);
 
-        transition = new TransitionBase<>(grandparent.getState(), grandchild2_1::getState, TransitionGuard.none());
+        transition = new TransitionBase<>(grandparent.getState(), grandchild2_1::getState, TransitionGuard.none(),
+                                          Action.noAction());
 
         actions.clear();
         grandparent.exit(null, transition, actions);
@@ -377,7 +382,7 @@ public class InternalStateTest {
 
         // Outside to child transitions
 
-        transition = new TransitionBase<>("", grandchild1_1::getState, TransitionGuard.none());
+        transition = new TransitionBase<>("", grandchild1_1::getState, TransitionGuard.none(), Action.noAction());
 
         actions.clear();
         grandparent.exit(null, transition, actions);
@@ -391,7 +396,8 @@ public class InternalStateTest {
 
         // Child to outside transitions
 
-        transition = new TransitionBase<>(grandchild1_1.getState(), () -> "", TransitionGuard.none());
+        transition = new TransitionBase<>(grandchild1_1.getState(), () -> "", TransitionGuard.none(),
+                                          Action.noAction());
 
         actions.clear();
         grandchild1_1.exit(null, transition, actions);

--- a/src/test/java/com/bnorm/infinite/StateMachineTest.java
+++ b/src/test/java/com/bnorm/infinite/StateMachineTest.java
@@ -88,7 +88,7 @@ public class StateMachineTest {
         turnstileBuilder.configure("Locked").handle("coin", "Unlocked");
         turnstileBuilder.configure("Unlocked").handle("push", "Locked");
         StateMachine<String, String, Void> turnstile = turnstileBuilder.build("Locked", null);
-        Optional<Transition<String, Void>> turnstileTransition;
+        Optional<Transition<String, String, Void>> turnstileTransition;
 
         turnstileTransition = turnstile.fire("coin");
         Assert.assertTrue(turnstileTransition.isPresent());
@@ -117,7 +117,7 @@ public class StateMachineTest {
         dvdplayerBuilder.configure("Playing").childOf("Active").handle("pause", "Paused");
         dvdplayerBuilder.configure("Paused").childOf("Active").handle("play", "Playing");
         StateMachine<String, String, AtomicBoolean> dvdplayer = dvdplayerBuilder.build("Stopped", containsDVD);
-        Optional<Transition<String, AtomicBoolean>> dvdplayerTransition;
+        Optional<Transition<String, String, AtomicBoolean>> dvdplayerTransition;
 
         dvdplayerTransition = dvdplayer.fire("play");
         Assert.assertFalse(dvdplayerTransition.isPresent());

--- a/src/test/java/com/bnorm/infinite/async/AsyncStateMachineTest.java
+++ b/src/test/java/com/bnorm/infinite/async/AsyncStateMachineTest.java
@@ -88,18 +88,18 @@ public class AsyncStateMachineTest {
         turnstileBuilder.configure("Unlocked").handle("push", "Locked");
         AsyncStateMachine<String, String, Void> turnstile = turnstileBuilder.build("Locked", null);
 
-        Future<Optional<Transition<String, Void>>> futureTurnstileTransition1 = turnstile.submit("coin");
-        Future<Optional<Transition<String, Void>>> futureTurnstileTransition2 = turnstile.submit("coin");
-        Future<Optional<Transition<String, Void>>> futureTurnstileTransition3 = turnstile.submit("push");
-        Future<Optional<Transition<String, Void>>> futureTurnstileTransition4 = turnstile.submit("push");
+        Future<Optional<Transition<String, String, Void>>> futureTurnstileTransition1 = turnstile.submit("coin");
+        Future<Optional<Transition<String, String, Void>>> futureTurnstileTransition2 = turnstile.submit("coin");
+        Future<Optional<Transition<String, String, Void>>> futureTurnstileTransition3 = turnstile.submit("push");
+        Future<Optional<Transition<String, String, Void>>> futureTurnstileTransition4 = turnstile.submit("push");
 
         Thread turnstileThread = new Thread(turnstile);
         turnstileThread.start();
 
-        Optional<Transition<String, Void>> turnstileTransition1 = futureTurnstileTransition1.get();
-        Optional<Transition<String, Void>> turnstileTransition2 = futureTurnstileTransition2.get();
-        Optional<Transition<String, Void>> turnstileTransition3 = futureTurnstileTransition3.get();
-        Optional<Transition<String, Void>> turnstileTransition4 = futureTurnstileTransition4.get();
+        Optional<Transition<String, String, Void>> turnstileTransition1 = futureTurnstileTransition1.get();
+        Optional<Transition<String, String, Void>> turnstileTransition2 = futureTurnstileTransition2.get();
+        Optional<Transition<String, String, Void>> turnstileTransition3 = futureTurnstileTransition3.get();
+        Optional<Transition<String, String, Void>> turnstileTransition4 = futureTurnstileTransition4.get();
 
 
         Assert.assertTrue(turnstileTransition1.isPresent());
@@ -128,30 +128,35 @@ public class AsyncStateMachineTest {
         dvdplayerBuilder.configure("Paused").childOf("Active").handle("play", "Playing");
         AsyncStateMachine<String, String, AtomicBoolean> dvdplayer = dvdplayerBuilder.build("Stopped", containsDVD);
 
-        Future<Optional<Transition<String, AtomicBoolean>>> futureDVDPlayerTransition1 = dvdplayer.submit("play");
-        Future<Optional<Transition<String, AtomicBoolean>>> futureDVDPlayerTransition2 = dvdplayer.submit("pause");
+        Future<Optional<Transition<String, String, AtomicBoolean>>> futureDVDPlayerTransition1 = dvdplayer.submit(
+                "play");
+        Future<Optional<Transition<String, String, AtomicBoolean>>> futureDVDPlayerTransition2 = dvdplayer.submit(
+                "pause");
 
         Thread dvdplayerThread = new Thread(dvdplayer);
         dvdplayerThread.start();
 
-        Optional<Transition<String, AtomicBoolean>> dvdplayerTransition1 = futureDVDPlayerTransition1.get();
-        Optional<Transition<String, AtomicBoolean>> dvdplayerTransition2 = futureDVDPlayerTransition2.get();
+        Optional<Transition<String, String, AtomicBoolean>> dvdplayerTransition1 = futureDVDPlayerTransition1.get();
+        Optional<Transition<String, String, AtomicBoolean>> dvdplayerTransition2 = futureDVDPlayerTransition2.get();
         Assert.assertFalse(dvdplayerTransition1.isPresent());
         Assert.assertFalse(dvdplayerTransition2.isPresent());
 
         dvdplayer.stop();
         containsDVD.set(true);
 
-        Future<Optional<Transition<String, AtomicBoolean>>> futureDVDPlayerTransition3 = dvdplayer.submit("play");
-        Future<Optional<Transition<String, AtomicBoolean>>> futureDVDPlayerTransition4 = dvdplayer.submit("pause");
-        Future<Optional<Transition<String, AtomicBoolean>>> futureDVDPlayerTransition5 = dvdplayer.inject("stop");
+        Future<Optional<Transition<String, String, AtomicBoolean>>> futureDVDPlayerTransition3 = dvdplayer.submit(
+                "play");
+        Future<Optional<Transition<String, String, AtomicBoolean>>> futureDVDPlayerTransition4 = dvdplayer.submit(
+                "pause");
+        Future<Optional<Transition<String, String, AtomicBoolean>>> futureDVDPlayerTransition5 = dvdplayer.inject(
+                "stop");
 
         dvdplayerThread = new Thread(dvdplayer);
         dvdplayerThread.start();
 
-        Optional<Transition<String, AtomicBoolean>> dvdplayerTransition3 = futureDVDPlayerTransition3.get();
-        Optional<Transition<String, AtomicBoolean>> dvdplayerTransition4 = futureDVDPlayerTransition4.get();
-        Optional<Transition<String, AtomicBoolean>> dvdplayerTransition5 = futureDVDPlayerTransition5.get();
+        Optional<Transition<String, String, AtomicBoolean>> dvdplayerTransition3 = futureDVDPlayerTransition3.get();
+        Optional<Transition<String, String, AtomicBoolean>> dvdplayerTransition4 = futureDVDPlayerTransition4.get();
+        Optional<Transition<String, String, AtomicBoolean>> dvdplayerTransition5 = futureDVDPlayerTransition5.get();
         Assert.assertTrue(dvdplayerTransition3.isPresent());
         Assert.assertEquals("Stopped", dvdplayerTransition3.get().getSource());
         Assert.assertEquals("Playing", dvdplayerTransition3.get().getDestination());
@@ -164,20 +169,23 @@ public class AsyncStateMachineTest {
         dvdplayerThread = new Thread(dvdplayer);
         dvdplayerThread.start();
 
-        Future<Optional<Transition<String, AtomicBoolean>>> futureDVDPlayerTransition6 = dvdplayer.submit("play");
-        Optional<Transition<String, AtomicBoolean>> dvdplayerTransition7 = dvdplayer.fire("pause");
+        Future<Optional<Transition<String, String, AtomicBoolean>>> futureDVDPlayerTransition6 = dvdplayer.submit(
+                "play");
+        Optional<Transition<String, String, AtomicBoolean>> dvdplayerTransition7 = dvdplayer.fire("pause");
 
         dvdplayer.stop();
         dvdplayerThread = new Thread(dvdplayer);
 
-        Future<Optional<Transition<String, AtomicBoolean>>> futureDVDPlayerTransition8 = dvdplayer.submit("play");
-        Future<Optional<Transition<String, AtomicBoolean>>> futureDVDPlayerTransition9 = dvdplayer.inject("stop");
+        Future<Optional<Transition<String, String, AtomicBoolean>>> futureDVDPlayerTransition8 = dvdplayer.submit(
+                "play");
+        Future<Optional<Transition<String, String, AtomicBoolean>>> futureDVDPlayerTransition9 = dvdplayer.inject(
+                "stop");
 
         dvdplayerThread.start();
 
-        Optional<Transition<String, AtomicBoolean>> dvdplayerTransition6 = futureDVDPlayerTransition6.get();
-        Optional<Transition<String, AtomicBoolean>> dvdplayerTransition8 = futureDVDPlayerTransition8.get();
-        Optional<Transition<String, AtomicBoolean>> dvdplayerTransition9 = futureDVDPlayerTransition9.get();
+        Optional<Transition<String, String, AtomicBoolean>> dvdplayerTransition6 = futureDVDPlayerTransition6.get();
+        Optional<Transition<String, String, AtomicBoolean>> dvdplayerTransition8 = futureDVDPlayerTransition8.get();
+        Optional<Transition<String, String, AtomicBoolean>> dvdplayerTransition9 = futureDVDPlayerTransition9.get();
 
         Assert.assertTrue(dvdplayerTransition6.isPresent());
         Assert.assertEquals("Paused", dvdplayerTransition6.get().getSource());


### PR DESCRIPTION
Fixes #70 

This changes the API a little for transitions as they now require
knowledge of the event type of the state machine.  Since the state
machine library is still quite beta, updates like this should be
expected.